### PR TITLE
docs: add Apple Silicon support to commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,27 @@ brew install bash
 
 3. Add the new shell to the list of allowed shells:
 
+**Apple M Processors**
+
+```console
+sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
+```
+
+**Intel Processors**
+
 ```console
 sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
 ```
 
 4. Optionally, make it your default shell:
+
+**Apple M Processors**
+
+```console
+chsh -s /opt/homebrew/bin/bash
+```
+
+**Intel Processors**
 
 ```console
 chsh -s /usr/local/bin/bash

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ brew install bash
 
 3. Add the new shell to the list of allowed shells:
 
-**Apple M Processors**
+**Apple Silicon processors**
 
 ```console
 sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
 ```
 
-**Intel Processors**
+**Intel processors**
 
 ```console
 sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
@@ -133,13 +133,13 @@ sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
 
 4. Optionally, make it your default shell:
 
-**Apple M Processors**
+**Apple Silicon processors**
 
 ```console
 chsh -s /opt/homebrew/bin/bash
 ```
 
-**Intel Processors**
+**Intel processors**
 
 ```console
 chsh -s /usr/local/bin/bash


### PR DESCRIPTION
This change adds support for Apple Silicon processors as Homebrew's install path is `/opt/homebrew` on ARM architecture. This is a change from x86 processors where the path still remains `/usr/local`.

For more info on this you can read the [official documentation](https://docs.brew.sh/FAQ#why-is-the-default-installation-prefix-opthomebrew-on-apple-silicon) or this [reddit thread](https://www.reddit.com/r/MacOS/comments/jw9guu/comment/gcoxkgg/) with a response from a Homebrew contributor.