### PR TITLE
Added Podman instructions and enhance Docker run to avoid multiple containers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,18 @@
+# Base image
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian AS base
+
+# Update packages
+RUN apt-get update && \
+  apt-get install -y curl jq git xxd
+
+# Set the default shell to zsh
+ENV SHELL=/usr/bin/zsh
+SHELL ["/usr/bin/zsh", "-c"]
+
+# Copy foundry tools
+COPY --from=ghcr.io/foundry-rs/foundry:stable /usr/local/bin/chisel /usr/local/bin/chisel
+COPY --from=ghcr.io/foundry-rs/foundry:stable /usr/local/bin/cast /usr/local/bin/cast
+
+# Copy your script
+COPY safe_hashes.sh .
+ENTRYPOINT ["bash", "./safe_hashes.sh"]

--- a/README.md
+++ b/README.md
@@ -209,7 +209,21 @@ docker build -t safe_hashes .
 ### Run
 
 ```console
-docker run -it safe_hashes  [--help] [--list-networks] --network <network> --address <address> --nonce <nonce> --message <file>
+docker run -it --rm --name safe_hashes_container safe_hashes  [--help] [--list-networks] --network <network> --address <address> --nonce <nonce> --message <file>
+```
+
+## Podman
+
+### Build
+
+```console
+podman build -t safe_hashes .
+```
+
+### Run
+
+```console
+podman run -it --rm --name safe_hashes_container safe_hashes  [--help] [--list-networks] --network <network> --address <address> --nonce <nonce> --message <file>
 ```
 
 ## Dev Container


### PR DESCRIPTION
TLDR: Added Containerfile for Podman and updated the README to run in podman, enhanced Docker to remove the container after execution. 

== Copilot summary ==
This pull request introduces a new `Containerfile` for building a development container and updates the `README.md` to include instructions for using both Docker and Podman. The main goals are to standardize the container build process and provide clear usage guidance for different container runtimes.

**Containerization improvements:**

* Added a new `Containerfile` that defines a development container based on the VS Code devcontainers Debian image, installs required packages, sets up the shell, copies Foundry tools (`chisel`, `cast`), and sets the entrypoint to `safe_hashes.sh`.

**Documentation updates:**

* Updated the Docker run command in `README.md` to use `--rm` and a named container for better usability.
* Added detailed build and run instructions for Podman in `README.md` to support users of alternative container engines.